### PR TITLE
Fix Scourge Gryphon in Plaguelands: The Scarlet Enclave

### DIFF
--- a/world_updates/2012_02_26_00_creature_template.sql
+++ b/world_updates/2012_02_26_00_creature_template.sql
@@ -1,0 +1,2 @@
+-- FIX DK Scourge Gryphon 29488
+UPDATE `creature_template` SET `npcflag` = 16777216 WHERE `entry` = 29488;


### PR DESCRIPTION
Now you can fly to Deaths Breach
